### PR TITLE
🐛 [bug] 게시글 상세조회 닉네임 오류 수정 #85

### DIFF
--- a/src/main/java/com/sm/project/converter/community/PostConverter.java
+++ b/src/main/java/com/sm/project/converter/community/PostConverter.java
@@ -98,7 +98,7 @@ public class PostConverter {
                 .title(post.getTitle())
                 .status(post.getStatus())
                 .content(post.getContent())
-                .nickname(member.getNickname())
+                .nickname(post.getMember().getNickname())
                 .createdAt(post.getCreatedAt())
                 .itemImgUrlList(imgs)
                 .build();


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
게시글 상세조회에서 닉네임이 작성자가 아닌 자기 이름이 뜨는 오류 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- PostConverter

## ⏳ 작업 내용
- [x] PostConverter수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
